### PR TITLE
Finish runner_type workflow rollout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      runner_type:
+        description: "Runner type: 'self-hosted' (default) or 'github-hosted'"
+        type: choice
+        default: self-hosted
+        options:
+          - self-hosted
+          - github-hosted
 
 env:
   FOUNDRY_PROFILE: ci
@@ -14,7 +22,7 @@ jobs:
       fail-fast: true
 
     name: Foundry project
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && 'arm-runner' || fromJSON('["self-hosted","ARM64"]') }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Summary:
- finish runner_type parameterization for remaining active workflows
- migrate dispatch-based release/Slack workflows to native reusable workflows where present
- preserve optional Slack pr_labels empty fallback while requiring pr_url
- use ARM-safe uv Python provisioning where workflows moved onto ARM runners

Verification:
- git diff --check
- grep checked for aurelien-baudet/workflow-dispatch, ::set-output, setup-python, unparameterized runner literals, npm provenance, and Slack pr_url empty fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI workflow to support configurable runner selection for test execution, allowing flexibility in choosing between different runner environments when manually triggering tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscholes/IvCheckVerifier/pull/4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->